### PR TITLE
Use FQBN for Mega board in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 script:
   - build_platform uno
   - build_platform leonardo
-  - build_platform arduino:avr:mega
+  - build_platform 'arduino:avr:mega:cpu=atmega2560'
   - build_platform esp8266
   - doxygen
   - ./.travis_deploy_docs.sh


### PR DESCRIPTION
Recent versions of the Arduino IDE fail compilation when the FQBN for Mega is not specified:
```
avr-g++: error: missing device or architecture after '-mmcu='
```